### PR TITLE
Userwait

### DIFF
--- a/better-jamf-policy-deferral.py
+++ b/better-jamf-policy-deferral.py
@@ -27,6 +27,7 @@ import datetime
 import plistlib
 import subprocess
 from AppKit import NSWorkspace
+from SystemConfiguration import SCDynamicStoreCopyConsoleUser
 
 # Configuration
 # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
@@ -312,6 +313,12 @@ def main():
                            '{}.plist'.format(ld_label))
 
     if args.mode == 'prompt':
+        # Ensure a user is logged in
+        consoleuser = SCDynamicStoreCopyConsoleUser(None, None, None)[0]
+        if not consoleuser:
+            print "No use is logged in, so the prompt cannot appear. Exiting."
+            sys.exit(1)
+
         # Make sure the policy hasn't already been deferred
         if os.path.exists(ld_path):
             print "It appears the user has already chosen to defer this policy."

--- a/better-jamf-policy-deferral.py
+++ b/better-jamf-policy-deferral.py
@@ -316,7 +316,7 @@ def main():
         # Ensure a user is logged in
         consoleuser = SCDynamicStoreCopyConsoleUser(None, None, None)[0]
         if not consoleuser:
-            print "No use is logged in, so the prompt cannot appear. Exiting."
+            print "No user is logged in, so the prompt cannot appear. Exiting."
             sys.exit(1)
 
         # Make sure the policy hasn't already been deferred


### PR DESCRIPTION
Adds functionality to ensure a user owns the console to prevent the Jamf binary from hanging when trying to present a prompt at the loginwindow, where it cannot.